### PR TITLE
Feature/participants

### DIFF
--- a/scripts/awsicons/icon.py
+++ b/scripts/awsicons/icon.py
@@ -68,6 +68,14 @@ class Icon:
                 target=self.target, color=self.color
             )
 
+            puml_content += "!define {target}Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, {color}, {target}, {target})\n".format(
+                target=self.target, color=self.color
+            )
+
+            puml_content += "!define {target}Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, {color}, {target}, {target})\n".format(
+                target=self.target, color=self.color
+            )
+
             with open("{}/{}.puml".format(path, self.target), "w") as f:
                 f.write(puml_content)
 

--- a/scripts/awsicons/icon.py
+++ b/scripts/awsicons/icon.py
@@ -67,11 +67,9 @@ class Icon:
             puml_content += "!define {target}(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, {color}, {target}, {target})\n".format(
                 target=self.target, color=self.color
             )
-
             puml_content += "!define {target}Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, {color}, {target}, {target})\n".format(
                 target=self.target, color=self.color
             )
-
             puml_content += "!define {target}Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, {color}, {target}, {target})\n".format(
                 target=self.target, color=self.color
             )

--- a/source/AWSCommon.puml
+++ b/source/AWSCommon.puml
@@ -28,8 +28,12 @@ skinparam Arrow {
     FontSize 12
 }
 
-!definelong AWSEntityColoring(e_stereo)
-skinparam rectangle<<e_stereo>> {
+!definelong AWSEntityColoring(stereo)
+skinparam rectangle<<stereo>> {
+    BackgroundColor AWS_BG_COLOR
+    BorderColor AWS_BORDER_COLOR
+}
+skinparam participant<<stereo>> {
     BackgroundColor AWS_BG_COLOR
     BorderColor AWS_BORDER_COLOR
 }
@@ -57,4 +61,12 @@ rectangle "==e_label\n<color:e_color><$e_sprite></color>\n//<size:TECHN_FONT_SIZ
 
 !definelong AWSEntity(e_alias, e_label, e_techn, e_descr, e_color, e_sprite, e_stereo)
 rectangle "==e_label\n<color:e_color><$e_sprite></color>\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//\n\n e_descr" <<e_stereo>> as e_alias
+!enddefinelong
+
+!definelong AWSParticipant(p_alias, p_label, p_techn, p_color, p_sprite, p_stereo)
+participant "p_label\n<size:TECHN_FONT_SIZE>[p_techn]</size>" as p_alias << ($p_sprite, p_color) p_stereo>>
+!enddefinelong
+
+!definelong AWSParticipant(p_alias, p_label, p_techn, p_descr, p_color, p_sprite, p_stereo)
+participant "p_label\n<size:TECHN_FONT_SIZE>[p_techn]</size>\n\n p_descr" as p_alias << ($p_sprite, p_color) p_stereo>>
 !enddefinelong


### PR DESCRIPTION
Description of changes:
Adds participant types to the generated puml, this allows you to easily draw sequence diagrams, for example:
```
@startuml
!define AWSPuml /generated/dist/

!include AWSPuml/AWSCommon.puml
!include AWSPuml/Compute/all.puml
!include AWSPuml/Mobile/all.puml

actor User as user
APIGatewayParticipant(api,name,)
LambdaParticipant(lambda,TimeLambda,returns now)
user -> api: Asks time
api -> lambda: Invokes lambda
lambda -> api: Returns time now
api -> user: Returns time
@enduml

```
Will become:
![ota_sign_on](https://user-images.githubusercontent.com/40564467/57848050-df4fdf00-77cf-11e9-968a-2b53ecbf85b3.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
