### PR TITLE
Fixed icon-builder.py case typo that caused --check-env to fail

### DIFF
--- a/scripts/icon-builder.py
+++ b/scripts/icon-builder.py
@@ -39,7 +39,7 @@ SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-ic
 
 The table below lists all AWS symbols in the `dist/` directory, sorted by category.
 
-If you want to reference and use these files without Internet connectivity, you can also download the whole [*PlantUML Icons for AWS* dist](dist/) direcotry and reference it locally with PlantUML.
+If you want to reference and use these files without Internet connectivity, you can also download the whole [*PlantUML Icons for AWS* dist](dist/) directory and reference it locally with PlantUML.
 
 ## PNG images
 
@@ -95,7 +95,8 @@ def verify_environment():
         sys.exit(1)
     # Verify other files and folders exist
     dir = Path("../source")
-    q = dir / "AWScommon.puml"
+    q = dir / "AWSCommon.puml"
+    print (q )
     if not q.exists():
         print("File AWScommon.puml not found is source/ directory")
         sys.exit(1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Problem
When "icon-builder.py --check-env" is run, it fails because it's looking for AWS**c**ommon.puml.
However, what's there is "AWS**C**ommon.puml"
Also, some minor typos in MARKDOWN_PREFIX_TEMPLATE

Solution
Change the script to look for "AWS**C**ommon.puml.
Fix minor typos in MARKDOWN_PREFIX_TEMPLATE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
