### PR TITLE
Correcting README example for simplified view

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This code generates the following diagram:
 
 ### Simplified View
 
-In some cases, PlantUML diagrams may contain too much information, but are still usable for executive or higher level conversations. Using the `AWSSimplified.puml` file filters out a lot of the technical details, while keeping the interactions between entities. Here is an example of a technical view and simplified view. To generate the simplified view, uncomment the `!define` statement and regenerate the image.
+In some cases, PlantUML diagrams may contain too much information, but are still usable for executive or higher level conversations. Using the `AWSSimplified.puml` file filters out a lot of the technical details, while keeping the interactions between entities. Here is an example of a technical view and simplified view. To generate the simplified view, uncomment the `!includeurl` statement and regenerate the image.
 
 ```bash
 @startuml Two Modes - Technical View


### PR DESCRIPTION
*Description of changes:*
`README.md` incorrectly instructed users to uncomment the `!define` directive instead of the `!includeurl` directive in the example of the Simplified View

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
