### PR TITLE
Fix SQS icon example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This example shows AWS IoT processing of messages via the Rules Engine with an e
 !includeurl AWSPuml/InternetOfThings/IoTRule.puml
 !includeurl AWSPuml/InternetOfThings/IoTAction.puml
 !includeurl AWSPuml/Analytics/KinesisDataStreams.puml
-!includeurl AWSPuml/ApplicationIntegration/SimpleQueueServiceSQS.puml
+!includeurl AWSPuml/ApplicationIntegration/SQS.puml
 
 left to right direction
 
@@ -129,7 +129,7 @@ agent "Published Event" as event #fff
 
 IoTRule(iotRule, "Action Error Rule", "error if Kinesis fails")
 KinesisDataStreams(eventStream, "IoT Events", "2 shards")
-SimpleQueueServiceSQS(errorQueue, "Rule Error Queue", "failed Rule actions")
+SQS(errorQueue, "Rule Error Queue", "failed Rule actions")
 
 event --> iotRule : JSON message
 iotRule --> eventStream : messages


### PR DESCRIPTION
### Description of changes:

Following the current SQS example results in the following error.

```puml
@startuml Basic Usage - AWS IoT Rules Engine

!define AWSPuml https://raw.githubusercontent.com/awslabs/aws-icons-for-plantuml/master/dist
!includeurl AWSPuml/ApplicationIntegration/SimpleQueueServiceSQS.puml

SimpleQueueServiceSQS(errorQueue, "Rule Error Queue", "failed Rule actions")

@enduml
```

![Screen Shot 2020-08-28 at 9 30 34 AM](https://user-images.githubusercontent.com/12212345/91579386-24d6e380-e911-11ea-9176-4407cbc4399b.png)

This PR fixes the SQS example to reflect the new SQS path.

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
