### PR TITLE
Fix README.md with correct import for WorkDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This is the [`examples/HelloWorld.puml`](examples/HelloWorld.puml) diagram code:
 
 !define AWSPuml https://raw.githubusercontent.com/awslabs/aws-icons-for-plantuml/v11.1/dist
 !includeurl AWSPuml/AWSCommon.puml
-!includeurl AWSPuml/EndUserComputing/all.puml
+!includeurl AWSPuml/BusinessApplications/all.puml
 !includeurl AWSPuml/Storage/SimpleStorageService.puml
 
 actor "Person" as personAlias


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
WorkDocs is not in EndUserComputing, so your very first, simplest, example of using the library fails.
This has already been fixed in the actual HelloWorld.puml, but the Readme wasn't updated to match.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
